### PR TITLE
fix #2

### DIFF
--- a/vendor/puppeteer/src/common/util.ts
+++ b/vendor/puppeteer/src/common/util.ts
@@ -484,7 +484,7 @@ export async function getReadableFromProtocolStream(
     throw new Error('Cannot create a stream outside of Node.js environment.');
   }
 
-  const {Readable} = await import('stream');
+  const {Readable} = await import('https://deno.land/std@0.151.0/node/stream.ts');
 
   let eof = false;
   return new Readable({


### PR DESCRIPTION
I have found, around the project, that you're importing from `https://deno.land/std@0.151.0/node/stream.ts`:

https://github.com/ratson/puppeteer_plus/blob/68223f46614434d2f089068e07c5b9ace05e52ba/vendor/puppeteer/src/common/Page.ts#L18

https://github.com/ratson/puppeteer_plus/blob/68223f46614434d2f089068e07c5b9ace05e52ba/vendor/puppeteer/src/common/util.ts#L18

But those are static imports. There's one dynamic import that wasn't transformed:

https://github.com/ratson/puppeteer_plus/blob/68223f46614434d2f089068e07c5b9ace05e52ba/vendor/puppeteer/src/common/util.ts#L487

So this is a fix.